### PR TITLE
Specific minimal node version

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,6 +9,9 @@
   "scripts": {
     "test": "standard"
   },
+  "engines": {
+    "node": ">=6"
+  },
   "keywords": [
     "slow",
     "dependencies",


### PR DESCRIPTION
Since the dep [filecopy](https://github.com/okunishinishi/node-filecopy) requires `node>=6`
