### PR TITLE
feature: Support exclude optional dependencies argument

### DIFF
--- a/index.js
+++ b/index.js
@@ -31,9 +31,13 @@ temp.track()
 function getDeps () {
   return readFile('package.json', 'utf8').then(function (str) {
     var json = JSON.parse(str)
-    var deps = extend({}, json.dependencies, json.optionalDependencies)
+    var deps = extend({}, json.dependencies)
     if (process.argv.indexOf('--production') === -1) {
       extend(deps, json.devDependencies)
+    }
+    // Include optionalDependencies only if --no-optional argument is absent
+    if (process.argv.indexOf('--no-optional') === -1) {
+      extend(deps, json.optionalDependencies)
     }
     console.log('Analyzing ' + Object.keys(deps).length + ' dependencies...')
     return deps


### PR DESCRIPTION
As of now I have just added the `--no-optional` argument via string matching.

@nolanlawson Later we can shift the entire thing to use `yargs`. I have used it a lot in some of my projects. I can take that up as well. Let me know what do you think.

/Fixes #5 
