### PR TITLE
Add support for npm-shrinkwrap.json

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,7 @@ Usage: slow-deps [options]
 Options:
   --production, --prod  Skip devDependencies                           [boolean]
   --no-optional         Skip optionalDependencies                      [boolean]
+  --no-shrinkwrap       Ignore npm-shrinkwrap.json                     [boolean]
   -h, --help            Show help                                      [boolean]
 
 Examples:


### PR DESCRIPTION
This slightly changes how `slow-deps` installs packages.

For each dependency, a temporary package.json and (where needed) a npm-shrinkwrap.json files are created with the infos relative to the current dependency.
Since there is a package.json, the package can be installed with just an `npm install`.
In this way, npm will handle the npm-shrinkwrap.json file for us, if present.

Solves #1 